### PR TITLE
Update React peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "textarea-caret": "git://github.com/mattkrick/textarea-caret-position.git#ede461f40712238c505e4a1861fc68de6e7731ad"
   },
   "peerDependencies": {
-    "react": "^15.4.2",
-    "react-dom": "^15.4.2"
+    "react": "^15.4.2 || ^16.0.0",
+    "react-dom": "^15.4.2 || ^16.0.0"
   }
 }


### PR DESCRIPTION
Yarn was emitting warnings about `@folio/react-githubish-mentions` requesting `react` and `react-dom` 15 in its peer dependencies. The rest of the `@folio/stripes` ecosystem is on 16.

I'm assuming this package works on React 16?